### PR TITLE
Feat/name plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ fastify.addHook('preHandler', function (request, reply, done) {
 ```
 Properties from `reply.locals` will override those from `defaultContext`, but not from `data` parameter provided to `reply.view(template, data)` function.
 
+To require `point-of-view` as a dependency to a [fastify-plugin](https://github.com/fastify/fastify-plugin) add the name `point-of-view` to the depencencies array in the [plugin's opts](https://github.com/fastify/fastify-plugin#dependencies).
+
+```
+  {
+    dependencies: ['point-of-view] 
+  }
+```
+
 <a name="note"></a>
 ## Note
 

--- a/index.js
+++ b/index.js
@@ -600,4 +600,7 @@ function fastifyView (fastify, opts, next) {
   }
 }
 
-module.exports = fp(fastifyView, { fastify: '>=3.x' })
+module.exports = fp(fastifyView, {
+  fastify: '>=3.x',
+  name: 'point-of-view'
+})

--- a/test/test.js
+++ b/test/test.js
@@ -188,11 +188,9 @@ test('plugin is registered with "point-of-view" name', t => {
   fastify.ready(err => {
     t.error(err)
 
-    const symbolKey = Reflect.ownKeys(fastify)
-      .find(key => key.toString() === 'Symbol(registered-plugin)')
-    const registeredPlugins = fastify[symbolKey]
-    const checkPointOfViewName = (name) => name === 'point-of-view'
-    t.ok(registeredPlugins.find(checkPointOfViewName))
+    const kRegistedPlugins = Symbol.for('registered-plugin')
+    const registeredPlugins = fastify[kRegistedPlugins]
+    t.ok(registeredPlugins.find(name => name === 'point-of-view'))
 
     fastify.close()
   })

--- a/test/test.js
+++ b/test/test.js
@@ -174,3 +174,26 @@ test('register callback should throw if layout option provided with wrong engine
     t.is(err.message, 'Only Handlebars, EJS, and Eta support the "layout" option')
   })
 })
+
+test('plugin is registered with "point-of-view" name', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: require('ejs')
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const symbolKey = Reflect.ownKeys(fastify)
+      .find(key => key.toString() === 'Symbol(registered-plugin)')
+    const registeredPlugins = fastify[symbolKey]
+    const checkPointOfViewName = (name) => name === 'point-of-view'
+    t.ok(registeredPlugins.find(checkPointOfViewName))
+
+    fastify.close()
+  })
+})


### PR DESCRIPTION
### Summary
- Name the plugin 'point-of-view' so it can be required as a [plugin dependency](https://github.com/fastify/fastify-plugin#dependencies).
- Add instructions for requiring `point-of-view` as a plugin dependency in `README.md`.
-  Create test for name registration

###  Test plan
- run tests
```
$ npm run test
```
- If all tests pass, the  `point-of-view` plugin  has been registered with the name: 'point-of-view'
#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
